### PR TITLE
Normalize answer comparison to be case insensitive

### DIFF
--- a/src/components/AnswerForm.tsx
+++ b/src/components/AnswerForm.tsx
@@ -13,7 +13,7 @@ const AnswerForm = () => {
 		const correctAnswer = reverseAnswer(keys[currentPage]?.answer);
 		const key = keys[currentPage]?.key;
 
-		if (answer.trim().toLowerCase() == correctAnswer) {
+		if (answer.trim().toLowerCase() == correctAnswer.toLowerCase()) {
 			setValue('correctAnswer', true);
 
 			let result = `Poprawnie!`;


### PR DESCRIPTION
The website does not accept answers to some pages (e.g 3 or 9).
The root cause is comparing a lowercased answer given by user to an expected answer containing uppercase characters.